### PR TITLE
A bunch of styling tweaks

### DIFF
--- a/source/_header.erb
+++ b/source/_header.erb
@@ -14,7 +14,7 @@
          "faq" => "FAQs"
        }.each do |path, name| %>
        <% current = "#{path}.html" == current_page.path || path == current_page.data.menu_item %>
-       <%= link_to name, "/#{path}.html", class: "w-full xl:w-auto mb-8 xl:mb-0 #{current ? "xl:border-b-2 border-orange" : nil}" %>
+       <%= link_to name, "/#{path}.html", class: "w-full xl:w-auto mb-8 xl:mb-0 #{current ? "xl:border-b-2 border-orange" : nil} hover:text-orange" %>
     <% end %>
   </nav>
 </header>

--- a/source/about_us.html.erb
+++ b/source/about_us.html.erb
@@ -14,7 +14,7 @@ title: About us
     </p>
 
     <h2 class="text-4xl xl:text-5xl text-blue-dark mb-6">The Team</h2>
-    <div class="xl:flex flex-wrap justify-between mb-12 xl:mb-24">
+    <div class="xl:flex flex-wrap justify-center mb-12 xl:mb-24">
       <% data.team.members.each do |member| %>
         <div class="text-center xl:w-1/3 xl:px-4 mb-12 xl:mb-0">
           <%= image_tag member.photo, class: "inline-block mb-6 rounded-full", style: "width: 19rem" %>

--- a/source/faq.html.erb
+++ b/source/faq.html.erb
@@ -1,8 +1,8 @@
 ---
 title: FAQs
 ---
-<main class="bg-white">
-  <div class="container mx-auto px-4 sm:px-8 xl:px-24 xxl:px-48 pt-6 sm:pt-12 xl:pt-16 text-blue-dark">
+<main class="bg-gray-light">
+  <div class="container mx-auto px-4 sm:px-8 xl:px-24 xxl:px-48 pt-6 sm:pt-12 xl:pt-16 text-blue-dark xl:pb-16">
     <h1 class="text-4xl xl:text-5xl text-blue-dark xl:mt-6 mb-6">FAQs</h1>
     <a name="top"></a>
     <ul class="text-blue-dark text-xl xl:text-2xl mb-8 sm:mb-16 leading-tight xl:leading-normal">
@@ -48,7 +48,7 @@ title: FAQs
         </div>
       </div>
     <% end %>
-    <p class="hidden xl:block text-right mb-16">
+    <p class="hidden xl:block text-right">
       <a href="#top" class="text-text-default text-sm">Back to top</a>
     </p>
   </div>

--- a/source/why_flight_free.html.erb
+++ b/source/why_flight_free.html.erb
@@ -1,7 +1,7 @@
 ---
 title: Why flight free?
 ---
-<main class="bg-white">
+<main class="bg-gray-light">
   <div class="container mx-auto px-4 sm:px-8 xl:px-16 xxl:px-48 pt-6 sm:pt-12 xl:pt-24 pb-12 text-text-default">
     <h1 class="text-4xl xl:text-5xl text-blue-dark mb-6">Why Flight Free?</h1>
     <p class="text-2xl xl:text-3xl mb-12 xl:mb-16 leading-tight text-text-gray-light">Aviation is the fastest growing contributor to greenhouse gas emissions at a time when we desperately need to reduce them.</p>


### PR DESCRIPTION
From Anna:

* Differentiate between hover and active state links in nav bar, e.g. text change to orange on hover, underline to appear on active
* Background for Why Flight Free & FAQs is white whereas Be Inspired, Podcast, About us, Downloads, Ts&Cs backgrounds are a cream colour. Can those first two also be cream?
* ~Blog: Quote function to stand out as a quote (Rosa designed this)~
* About us: layout of bottom line, when there are two profiles there, there’s a gap in the middle. It would be better to have the gap on the right hand side.